### PR TITLE
feat: add transparent window example and support

### DIFF
--- a/examples/transparent.mjs
+++ b/examples/transparent.mjs
@@ -1,0 +1,20 @@
+import { Application } from "../index.js";
+
+const app = new Application();
+const window = app.createBrowserWindow({
+  transparent: true,
+  decorations: false,
+});
+
+const webview = window.createWebview({
+    html: /* html */ `
+      <html>
+        <body style="background-color:rgba(87,87,87,0.5);">
+          <h1>Hello, transparent!</h1>
+        </body>
+      </html>`,
+    transparent: true,
+    enableDevtools: true,
+});
+
+app.run();

--- a/src/browser_window.rs
+++ b/src/browser_window.rs
@@ -209,6 +209,15 @@ impl BrowserWindow {
       window = window.with_focused(focused);
     }
 
+    if let Some(transparent) = options.transparent {
+      window = window.with_transparent(transparent);
+      #[cfg(target_os = "windows")]
+      {
+        use tao::platform::windows::WindowBuilderExtWindows;
+        window = window.with_undecorated_shadow(false);
+      }
+    }
+
     if let Some(fullscreen) = options.fullscreen {
       let fs = match fullscreen {
         // Some(FullscreenType::Exclusive) => Some(Fullscreen::Exclusive()),


### PR DESCRIPTION
https://github.com/webviewjs/webview/issues/10
This PR implements the transparent mode. To achieve transparency, three steps are required:

1. Set the window's transparent property to true and decorations to false.
2. Set the webview to be transparent.
3. Set the HTML to be transparent.

Here’s an example code snippet:
```js
const app = new Application();
const window = app.createBrowserWindow({
  transparent: true,
  decorations: false,
});

const webview = window.createWebview({
    html: /* html */ `
      <html>
        <body style="background-color:rgba(87,87,87,0.5);">
          <h1>Hello, transparent!</h1>
        </body>
      </html>`,
    transparent: true,
});

app.run();
```