### PR TITLE
feat: add BrowserWindow.setSize() method for dynamic window resizing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,8 @@ export declare class BrowserWindow {
   setMinimizable(minimizable: boolean): void
   /** Sets resizable. */
   setResizable(resizable: boolean): void
+  /** Sets the window inner size (width and height). */
+  setSize(width: number, height: number): void
   /** Gets the window ID. */
   id(): number
   /** Gets whether the window has a menu. */

--- a/src/browser_window.rs
+++ b/src/browser_window.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
 use tao::{
-  dpi::{LogicalPosition, PhysicalSize},
+  dpi::{LogicalPosition, LogicalSize, PhysicalSize},
   event_loop::EventLoop,
   window::{Fullscreen, ProgressBarState, Window, WindowBuilder, WindowId},
 };
@@ -436,6 +436,12 @@ impl BrowserWindow {
   /// Sets resizable.
   pub fn set_resizable(&self, resizable: bool) {
     self.window.set_resizable(resizable);
+  }
+
+  #[napi]
+  /// Sets the window inner size (width and height).
+  pub fn set_size(&self, width: u32, height: u32) {
+    self.window.set_inner_size(LogicalSize::new(width, height));
   }
 
   #[napi]


### PR DESCRIPTION
Implemented `setSize(width, height)` method on `BrowserWindow` for dynamic window resizing via JavaScript.

Tested on Windows.

Closes #34