### PR TITLE
Add "open_file_dialog()" function to browser window class

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ napi        = { version = "3.8.2", default-features = true, features = ["napi9"]
 napi-derive = "3.5.1"
 tao         = { version = "0.34.5", features = ["rwh_06"] }
 wry         = { version = "0.53.5", features = ["devtools", "fullscreen"] }
+rfd         = "0.15.4"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 muda = { version = "0.17", features = ["libxdo"] }

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,8 @@ export declare class BrowserWindow {
   setResizable(resizable: boolean): void
   /** Sets the window inner size (width and height). */
   setSize(width: number, height: number): void
+  /** Opens a file select dialog */
+  openFileDialog(options?: FileDialogOptions | undefined | null): Array<string>
   /** Gets the window ID. */
   id(): number
   /** Gets whether the window has a menu. */
@@ -229,6 +231,24 @@ export interface Dimensions {
   width: number
   /** The height of the size. */
   height: number
+}
+
+export interface FileDialogOptions {
+  /** Whether to allow selecting multiple files. */
+  multiple?: boolean
+  /** The title of the file dialog. */
+  title?: string
+  /** The initial directory of the file dialog. */
+  defaultPath?: string
+  /** The file types that can be selected in the file dialog. */
+  filters?: Array<FileFilter>
+}
+
+export interface FileFilter {
+  /** The name of the file filter. */
+  name: string
+  /** The extensions of the file filter. */
+  extensions: Array<string>
 }
 
 export declare const enum FullscreenType {

--- a/src/browser_window.rs
+++ b/src/browser_window.rs
@@ -8,6 +8,7 @@ use tao::{
   event_loop::EventLoop,
   window::{Fullscreen, ProgressBarState, Window, WindowBuilder, WindowId},
 };
+use rfd::FileDialog;
 #[cfg(not(target_os = "android"))]
 use muda::Menu;
 
@@ -129,6 +130,26 @@ pub struct BrowserWindowOptions {
   pub transparent: Option<bool>,
   /// The fullscreen state of the window.
   pub fullscreen: Option<FullscreenType>,
+}
+
+#[napi(object)]
+pub struct FileDialogOptions {
+  /// Whether to allow selecting multiple files.
+  pub multiple: Option<bool>,
+  /// The title of the file dialog.
+  pub title: Option<String>,
+  /// The initial directory of the file dialog.
+  pub default_path: Option<String>,
+  /// The file types that can be selected in the file dialog.
+  pub filters: Option<Vec<FileFilter>>,
+}
+
+#[napi(object)]
+pub struct FileFilter {
+  /// The name of the file filter.
+  pub name: String,
+  /// The extensions of the file filter.
+  pub extensions: Vec<String>,
 }
 
 impl Default for BrowserWindowOptions {
@@ -442,6 +463,51 @@ impl BrowserWindow {
   /// Sets the window inner size (width and height).
   pub fn set_size(&self, width: u32, height: u32) {
     self.window.set_inner_size(LogicalSize::new(width, height));
+  }
+
+  #[napi]
+  /// Opens a file select dialog
+  pub fn open_file_dialog(&self, options: Option<FileDialogOptions>) -> Result<Vec<String>> {
+    let mut dialog = FileDialog::new();
+
+    if let Some(opts) = options.as_ref() {
+      if let Some(title) = &opts.title {
+        dialog = dialog.set_title(title);
+      }
+
+      if let Some(path) = &opts.default_path {
+        dialog = dialog.set_directory(path);
+      }
+
+      if let Some(filters) = &opts.filters {
+        for filter in filters {
+          dialog = dialog.add_filter(
+            &filter.name,
+            &filter.extensions,
+          );
+        }
+      }
+    }
+
+    dialog = dialog.add_filter("All Files", &["*"]);
+
+    let files = if options
+      .as_ref()
+      .and_then(|o| o.multiple)
+      .unwrap_or(false)
+    {
+      dialog.pick_files()
+    } else {
+      dialog.pick_file().map(|f| vec![f])
+    };
+
+    Ok(
+      files
+        .unwrap_or_default()
+        .into_iter()
+        .map(|f| f.as_path().to_string_lossy().to_string())
+        .collect()
+    )
   }
 
   #[napi]


### PR DESCRIPTION
This will open a file browser window that can be customised via the "FileDialogOptions" and "FileFilter" interfaces.
This is needed because webview2 file inputs cannot get the path of selected items due to browser sucurity policies.

(I need this for something I'm working on using this package)