### PR TITLE
fix: Add js-bindings.js and js-bindings.d.ts to the files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "files": [
     "cli",
     "index.d.ts",
-    "index.js"
+    "index.js",
+    "js-bindings.js",
+    "js-bindings.d.ts"
   ],
   "napi": {
     "binaryName": "webview",


### PR DESCRIPTION
@twlite Please handle this as soon as possible.

Add js-bindings.js and js-bindings.d.ts to the files

Otherwise, this kind of error will happen:

```
node:internal/modules/cjs/loader:1244
  const err = new Error(message);
              ^

Error: Cannot find module './js-bindings.js'
Require stack:
- /home/administrator/webviewjstest/node_modules/.pnpm/@webviewjs+webview@0.2.0/node_modules/@webviewjs/webview/index.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1244:15)
    at Function._load (node:internal/modules/cjs/loader:1070:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1335:12)
    at require (node:internal/modules/helpers:136:16)
    at Object.<anonymous> (/home/administrator/webviewjstest/node_modules/.pnpm/@webviewjs+webview@0.2.0/node_modules/@webviewjs/webview/index.js:1:23)
    at Module._compile (node:internal/modules/cjs/loader:1562:14)
    at Object..js (node:internal/modules/cjs/loader:1699:10)
    at Module.load (node:internal/modules/cjs/loader:1313:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/administrator/webviewjstest/node_modules/.pnpm/@webviewjs+webview@0.2.0/node_modules/@webviewjs/webview/index.js'
  ]
}

Node.js v22.13.0
```